### PR TITLE
remove marks hack

### DIFF
--- a/ftplugin/haskell/hindent.vim
+++ b/ftplugin/haskell/hindent.vim
@@ -1,6 +1,4 @@
 function! s:Hindent()
-    "set dummy mark to save cursor position
-    execute "norm mz"
     let l:winview = winsaveview()
 
     if !executable("hindent")
@@ -17,10 +15,6 @@ function! s:Hindent()
         silent! execute "%!hindent"
     endif
 
-    " jump back to previous position
-    execute "norm `z"
-    " rm dummy mark
-    execute "delmarks z"
     call winrestview(l:winview)
 
 endfunction


### PR DESCRIPTION
I tested it and it seems that setting a mark makes no difference. `winrestview` works by itself, and doesn't overwrite your marks.