### PR TITLE
Four small changes

### DIFF
--- a/ftplugin/haskell/hindent.vim
+++ b/ftplugin/haskell/hindent.vim
@@ -15,7 +15,7 @@ function! hindent#Hindent()
         return
     endif
 
-    silent! silent exe "keepjumps !hindent < % > /dev/null 2>&1"
+    let l:result = system("hindent < % > /dev/null 2>&1")
 
     if v:shell_error
         echomsg "Hindent: Parsing error"

--- a/ftplugin/haskell/hindent.vim
+++ b/ftplugin/haskell/hindent.vim
@@ -44,3 +44,7 @@ if g:hindent_on_save == 1
         autocmd BufWritePre *.hs call hindent#Hindent()
     augroup END
 endif
+
+
+" For use with the gq operator (:help gq)
+setlocal formatprg=hindent

--- a/ftplugin/haskell/hindent.vim
+++ b/ftplugin/haskell/hindent.vim
@@ -24,7 +24,6 @@ function! hindent#Hindent()
     endif
 
     silent! silent exe "keepjumps !hindent < % > /dev/null 2>&1"
-    exe 'redraw!'
 
     if v:shell_error
         echomsg "Hindent: Parsing error"
@@ -42,6 +41,6 @@ endfunction
 if exists("g:hindent_on_save") && g:hindent_on_save == 1
     augroup hindent
         autocmd!
-        autocmd BufWritePost *.hs call hindent#Hindent()
+        autocmd BufWritePre *.hs call hindent#Hindent()
     augroup END
 endif

--- a/ftplugin/haskell/hindent.vim
+++ b/ftplugin/haskell/hindent.vim
@@ -1,11 +1,3 @@
-if !exists("g:hindent_indent_size")
-    let g:hindent_indent_size = 2
-endif
-
-if !exists("g:hindent_line_length")
-    let g:hindent_line_length = 100
-endif
-
 if !exists("g:hindent_on_save")
     let g:hindent_on_save = 1
 endif
@@ -28,10 +20,18 @@ function! hindent#Hindent()
     if v:shell_error
         echomsg "Hindent: Parsing error"
     else
+        let l:indent_opt = ""
+        if exists("g:hindent_indent_size")
+          let l:indent_opt = " --indent-size " . g:hindent_indent_size
+        endif
+
+        let l:line_length_opt = ""
+        if exists("g:hindent_line_length")
+          let l:line_length_opt = " --line-length " . g:hindent_line_length
+        endif
+
         silent! exe "undojoin"
-        silent! exe "keepjumps %!hindent" .
-                    \ " --indent-size " . g:hindent_indent_size .
-                    \ " --line-length " . g:hindent_line_length
+        silent! exe "keepjumps %!hindent" . l:indent_opt . l:line_length_opt
     endif
 
     call winrestview(l:winview)

--- a/ftplugin/haskell/hindent.vim
+++ b/ftplugin/haskell/hindent.vim
@@ -38,7 +38,7 @@ function! hindent#Hindent()
 endfunction
 
 
-if exists("g:hindent_on_save") && g:hindent_on_save == 1
+if g:hindent_on_save == 1
     augroup hindent
         autocmd!
         autocmd BufWritePre *.hs call hindent#Hindent()


### PR DESCRIPTION
This PR contains multiple independent changes. If you only want to include some
of them, I'm happy to update and resubmit the PR. Each change is in a separate
commit and can be reviewed separately.

- **Reformat text *before* writing**

  This is important so that the changes actually get saved. Also makes the
  exe 'redraw!' unnessary.

- **Allow vim-hindent to work with .hindent.yaml file**

  Before, vim-hindent always used the value of `g:hindent_indent_size` and
  `g:hindent_line_length`. These would always override values set in a
  `.hindent.yaml` file.

  Now, these Vim global variables do not take precedence if they don't exist.

- **Remove unnessary check**

  This check is unnessary. `g:hindent_on_save` is guaranteed to always be
  populated (see the top of the file).

- **Set up formatprg=hindent**

  hindent suggests adding this setting for Haskell files. The value of
  formatprg is used when reformatting text with the 'gq' operator. The
  default formatprg just hard-wraps prose text, which isn't something you'd
  ever use in a Haskell file.

- **Use system instead of `!`**

  The v:shell_error wasn't always being set correctly when using '!',
  which meant that sometimes hindent would overwrite the buffer with an
  error message.

